### PR TITLE
improved dead body handling

### DIFF
--- a/client2/src/components/controls-bar/controls-bar.tsx
+++ b/client2/src/components/controls-bar/controls-bar.tsx
@@ -128,7 +128,7 @@ export const ControlsBar: React.FC = () => {
 
         if (keyboard.keyCode === 'KeyC') setMinimized(!minimized)
 
-        if (appState.updatesPerSecond === 0) {
+        if (appState.paused) {
             // Paused
             if (keyboard.keyCode === 'ArrowRight') stepTurn(1)
             if (keyboard.keyCode === 'ArrowLeft') stepTurn(-1)

--- a/client2/src/components/game/game-renderer.tsx
+++ b/client2/src/components/game/game-renderer.tsx
@@ -50,8 +50,8 @@ export const GameRenderer: React.FC = () => {
         const ctx = getCanvasContext(CanvasType.DYNAMIC)!
         ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
         map.draw(ctx)
-        currentTurn.bodies.draw(map.staticMap.dimension, match.getInterpolationFactor(), ctx)
-        currentTurn.actions.draw(map.staticMap.dimension, match.getInterpolationFactor(), ctx)
+        currentTurn.bodies.draw(match, ctx)
+        currentTurn.actions.draw(match, ctx)
     }, [activeMatch])
     useListenEvent(EventType.RENDER, render, [render])
 

--- a/client2/src/components/game/tooltip.tsx
+++ b/client2/src/components/game/tooltip.tsx
@@ -56,7 +56,7 @@ const Tooltip = ({ mapCanvas, overlayCanvas, wrapperRef }: TooltipProps) => {
 
     function getHoveredBody() {
         return appContext.state?.activeMatch?.map
-            ? appContext.state.activeMatch?.currentTurn.bodies.getByLocation(
+            ? appContext.state.activeMatch?.currentTurn.bodies.getBodyAtLocation(
                   tileCol,
                   appContext.state.activeMatch.map.dimension.height - 1 - tileRow
               )

--- a/client2/src/playback/Actions.ts
+++ b/client2/src/playback/Actions.ts
@@ -5,6 +5,7 @@ import * as renderUtils from '../util/RenderUtil'
 import * as vectorUtils from './Vector'
 import { Dimension } from './Map'
 import { Team } from './Game'
+import Match from './Match'
 
 export default class Actions {
     actions: Action[] = []
@@ -40,15 +41,19 @@ export default class Actions {
         return newActions
     }
 
-    draw(mapDimension: Dimension, interpFactor: number, ctx: CanvasRenderingContext2D) {
+    draw(match: Match, ctx: CanvasRenderingContext2D) {
         for (const action of this.actions) {
-            action.draw(mapDimension, interpFactor, ctx)
+            action.draw(match, ctx)
         }
     }
 }
 
 export class Action {
-    constructor(protected robotID: number, protected target: number, public duration: number = 1) {}
+    constructor(
+        protected robotID: number,
+        protected target: number,
+        public duration: number = 1
+    ) {}
 
     /**
      * Applies this action to the turn provided. If stat is provided, it will be mutated to reflect the action as well
@@ -57,7 +62,7 @@ export class Action {
      * @param stat if provided, this action will mutate the stat to reflect the action
      */
     apply(turn: Turn): void {}
-    draw(mapDimension: Dimension, interpFactor: number, ctx: CanvasRenderingContext2D) {}
+    draw(match: Match, ctx: CanvasRenderingContext2D) {}
     copy(): Action {
         // creates a new object using this object's prototype and all its parameters. this is a shallow copy, override this if you need a deep copy
         return Object.create(Object.getPrototypeOf(this), Object.getOwnPropertyDescriptors(this))
@@ -110,44 +115,37 @@ export const ACTION_DEFINITIONS: Record<number, typeof Action> = {
             assert(body.type === schema.BodyType.CARRIER, 'Cannot throw from non-carrier')
             body.clearResources()
         }
-        draw(mapDimension: Dimension, interpFactor: number, ctx: CanvasRenderingContext2D) {
+        draw(match: Match, ctx: CanvasRenderingContext2D) {
             //const targetLoc = turn.map.indexToLocation(this.target)
         }
     },
     [schema.Action.LAUNCH_ATTACK]: class Launch extends Action {
-        private drawLocationStart?: vectorUtils.InterpVector
-        private drawLocationEnd?: vectorUtils.InterpVector
-        private drawTeam?: Team
-
         apply(turn: Turn): void {
-            const body = turn.bodies.getById(this.robotID)
+            const body = turn.bodies.getById(this.robotID) ?? assert.fail('Attacking body not found')
             assert(body.type === schema.BodyType.LAUNCHER, 'Cannot launch from non-launcher')
+        }
+        draw(match: Match, ctx: CanvasRenderingContext2D) {
+            const body = match.currentTurn.bodies.getById(this.robotID) ?? assert.fail('Attacking body not found')
+            const interpStart = renderUtils.getInterpolatedCoords(
+                body.pos,
+                body.nextPos,
+                match.getInterpolationFactor()
+            )
 
-            this.drawTeam = body.team
-            this.drawLocationStart = { start: body.pos, end: body.nextPos }
-
+            let interpEnd
             // Target is negative when it represents a miss (map location hit). Otherwise,
             // the attack hit a bot so we must transform the target into the bot's location
             if (this.target >= 0) {
-                const targetBody = turn.bodies.getById(this.target)
-                this.drawLocationEnd = { start: targetBody.pos, end: targetBody.nextPos }
+                const targetBody =
+                    match.currentTurn.bodies.getById(this.target) ?? assert.fail('Attack target not found')
+                interpEnd = renderUtils.getInterpolatedCoords(
+                    targetBody.pos,
+                    targetBody.nextPos,
+                    match.getInterpolationFactor()
+                )
             } else {
-                const location = turn.map.indexToLocation(-this.target - 1)
-                this.drawLocationEnd = { start: location, end: location }
+                interpEnd = match.currentTurn.map.indexToLocation(-this.target - 1)
             }
-        }
-        draw(mapDimension: Dimension, interpFactor: number, ctx: CanvasRenderingContext2D) {
-            // Compute true start and end points of the projectile
-            const interpStart = renderUtils.getInterpolatedCoords(
-                this.drawLocationStart!.start,
-                this.drawLocationStart!.end,
-                interpFactor
-            )
-            const interpEnd = renderUtils.getInterpolatedCoords(
-                this.drawLocationEnd!.start,
-                this.drawLocationEnd!.end,
-                interpFactor
-            )
 
             // Compute the start and end points for the animation projectile
             const dir = vectorUtils.vectorSub(interpEnd, interpStart)
@@ -155,19 +153,19 @@ export const ACTION_DEFINITIONS: Record<number, typeof Action> = {
             vectorUtils.vectorMultiplyInPlace(dir, 1 / len)
             const projectileStart = vectorUtils.vectorAdd(
                 interpStart,
-                vectorUtils.vectorMultiply(dir, len * interpFactor)
+                vectorUtils.vectorMultiply(dir, len * match.getInterpolationFactor())
             )
             const projectileEnd = vectorUtils.vectorAdd(
                 interpStart,
-                vectorUtils.vectorMultiply(dir, len * Math.min(interpFactor + 0.2, 1.0))
+                vectorUtils.vectorMultiply(dir, len * Math.min(match.getInterpolationFactor() + 0.2, 1.0))
             )
 
             // True direction
             renderUtils.renderLine(
                 ctx,
-                renderUtils.getRenderCoords(interpStart.x, interpStart.y, mapDimension),
-                renderUtils.getRenderCoords(interpEnd.x, interpEnd.y, mapDimension),
-                this.drawTeam!,
+                renderUtils.getRenderCoords(interpStart.x, interpStart.y, match.currentTurn.map.staticMap.dimension),
+                renderUtils.getRenderCoords(interpEnd.x, interpEnd.y, match.currentTurn.map.staticMap.dimension),
+                body.team,
                 0.05,
                 0.1,
                 true
@@ -176,9 +174,17 @@ export const ACTION_DEFINITIONS: Record<number, typeof Action> = {
             // Projectile animation
             renderUtils.renderLine(
                 ctx,
-                renderUtils.getRenderCoords(projectileStart.x, projectileStart.y, mapDimension),
-                renderUtils.getRenderCoords(projectileEnd.x, projectileEnd.y, mapDimension),
-                this.drawTeam!,
+                renderUtils.getRenderCoords(
+                    projectileStart.x,
+                    projectileStart.y,
+                    match.currentTurn.map.staticMap.dimension
+                ),
+                renderUtils.getRenderCoords(
+                    projectileEnd.x,
+                    projectileEnd.y,
+                    match.currentTurn.map.staticMap.dimension
+                ),
+                body.team,
                 0.05,
                 1.0,
                 false

--- a/client2/src/playback/Turn.ts
+++ b/client2/src/playback/Turn.ts
@@ -31,9 +31,8 @@ export default class Turn {
         else this.stat = this.match.stats[this.turnNumber].copy()
 
         this.map.applyDelta(delta)
-        this.bodies.applyDelta(this, delta, nextDelta, () => {
-            this.actions.applyDelta(this, delta)
-        })
+        this.bodies.applyDelta(this, delta, nextDelta)
+        this.actions.applyDelta(this, delta)
 
         if (firstTimeComputingStat) {
             // finish computing stat and save to match


### PR DESCRIPTION
I think this will make things cleaner overall. The only weird thing that happens now is that there can be two bodies in one location at the same time (if one is dead, and a second moves into that square on the same turn after it died).

Also im not sure if our formatters are the same? Someone must not be using prettier, or didnt format before pushing something previously