### PR TITLE
Fix typo in comment

### DIFF
--- a/engine/src/main/battlecode/common/GlobalUpgrade.java
+++ b/engine/src/main/battlecode/common/GlobalUpgrade.java
@@ -8,7 +8,7 @@ package battlecode.common;
 public enum GlobalUpgrade {
 
     /**
-     * Action upgrade increases the amount cooldown drops per round by 6.
+     * Action upgrade increases the amount cooldown drops per round by 4.
      */
     ACTION(4, 0, 0),
 


### PR DESCRIPTION
The code says `ACTION(4, 0, 0)` not `ACTION(6, 0, 0)`, so the comment should say `4` not `6`.