### PR TITLE
Fix typo in the spec

### DIFF
--- a/specs/specs.md.html
+++ b/specs/specs.md.html
@@ -253,7 +253,7 @@ Every function you could possibly use to interact with the game can be found in 
 
 ## **Java language usage**
 
-Players may use classes from any of the packages listed in AllowedPackages.txt, except for classes listed in DisallowedPackages.txt. These files can be found [here](https://github.com/battlecode/battlecode24/tree/engine-functional/engine/src/main/battlecode/instrumenter/bytecode/resources).
+Players may use classes from any of the packages listed in AllowedPackages.txt, except for classes listed in DisallowedClasses.txt. These files can be found [here](https://github.com/battlecode/battlecode24/tree/engine-functional/engine/src/main/battlecode/instrumenter/bytecode/resources).
 
 Furthermore, the following restrictions apply:
 


### PR DESCRIPTION
- Fixes a typo in the spec
  - `DisallowedPackages.txt` -> `DisallowedClasses.txt`